### PR TITLE
Updated to new sql server IP

### DIFF
--- a/MealPlanner/src/main/resources/application.properties
+++ b/MealPlanner/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 
 # Spring resources
 spring.jpa.hibernate.ddl-auto=update
-spring.datasource.url=jdbc:mysql://192.168.0.168:3306/mealplanner
+spring.datasource.url=jdbc:mysql://174.109.29.129:3306/mealplanner
 spring.datasource.username=dev
 spring.datasource.password=password
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
Old MySQL server IP address was only locally accessible. Changed to externally accessible one and tested by using mobile hotspot to mimic an external client.